### PR TITLE
prep for pre13

### DIFF
--- a/modules/Nexus/module.php
+++ b/modules/Nexus/module.php
@@ -139,4 +139,8 @@ class Nexus extends Module
     }
 
   }
+
+    public function getDebugInfo(): array {
+        return [];
+    }
 }


### PR DESCRIPTION
with many of the latest changes this must be added to all modules to prevent the following error loading the modules tab in StaffCP
Class Nexus contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Module::getDebugInfo)